### PR TITLE
react-router-reduxで画面遷移を実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-dom": "~15.3.2",
     "react-redux": "^4.4.5",
     "react-router": "^3.0.0",
+    "react-router-redux": "^4.0.7",
     "redux": "^3.6.0",
     "redux-actions": "^0.13.0",
     "redux-thunk": "^2.1.0"
@@ -44,6 +45,9 @@
     "less": "^2.7.1",
     "less-loader": "^2.2.3",
     "postcss-loader": "^1.1.0",
+    "redux-devtools": "^3.3.2",
+    "redux-devtools-dock-monitor": "^1.1.1",
+    "redux-devtools-log-monitor": "^1.2.0",
     "style-loader": "^0.13.1",
     "url-loader": "^0.5.7",
     "watch": "^1.0.1",

--- a/src/js/actions/index.js
+++ b/src/js/actions/index.js
@@ -1,0 +1,15 @@
+import * as types from '../constants/ActionTypes'
+
+export function addTodo(text) {
+  return {
+    type: types.ADD_TODO,
+    text 
+  }
+}
+
+export function completeTodo(id) {
+  return {
+    type: types.COMPLETE_TODO,
+    id
+  }
+}

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import Main from './components/Main';
-import { Router, Route, hashHistory } from 'react-router';
+import Todo from './components/Todo';
 import User from './components/User';
+import { Router, Route, hashHistory } from 'react-router';
 
 ReactDOM.render((
   <Router history={hashHistory}>
-    <Route path="/" component={Main} />
+    <Route path="/" component={Todo} />
+    <Route path="/Todo" component={Todo} />
     <Route path="/User" component={User} />
   </Router>
 ), document.getElementById('main')

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -6,13 +6,12 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { createStore, combineReducers } from 'redux'
 import { Provider } from 'react-redux'
-import { Router, Route, IndexRoute, browserHistory } from 'react-router';
+import { Router, Route, browserHistory } from 'react-router';
 import { syncHistoryWithStore, routerReducer } from 'react-router-redux'
 
 import * as reducers from './reducers'
 import Todo from './components/Todo'
 import User from './components/User'
-import TodoApp from './containers/TodoApp'
 
 const reducer = combineReducers({
   ...reducers,
@@ -34,7 +33,14 @@ const history = syncHistoryWithStore(browserHistory, store)
 
 ReactDOM.render(
   <Provider store={store}>
-    <TodoApp />
+    <div>
+      <Router history={history}>
+        <Route path="/" component={User}/>
+        <Route path="User" component={User}/>
+        <Route path="Todo" component={Todo}/>
+      </Router>
+      <DevTools />
+    </div>
   </Provider>, 
   document.getElementById('main')
 );

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -2,10 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import Main from './components/Main';
 import { Router, Route, hashHistory } from 'react-router';
+import User from './components/User';
 
 ReactDOM.render((
   <Router history={hashHistory}>
     <Route path="/" component={Main} />
+    <Route path="/User" component={User} />
   </Router>
 ), document.getElementById('main')
 );

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1,15 +1,41 @@
+import { createDevTools } from 'redux-devtools'
+import LogMonitor from 'redux-devtools-log-monitor'
+import DockMonitor from 'redux-devtools-dock-monitor'
+
 import React from 'react';
 import ReactDOM from 'react-dom';
-import Todo from './components/Todo';
-import User from './components/User';
-import { Router, Route, hashHistory } from 'react-router';
+import { createStore, combineReducers } from 'redux'
+import { Provider } from 'react-redux'
+import { Router, Route, IndexRoute, browserHistory } from 'react-router';
+import { syncHistoryWithStore, routerReducer } from 'react-router-redux'
 
-ReactDOM.render((
-  <Router history={hashHistory}>
-    <Route path="/" component={Todo} />
-    <Route path="/Todo" component={Todo} />
-    <Route path="/User" component={User} />
-  </Router>
-), document.getElementById('main')
+import * as reducers from './reducers'
+import Todo from './components/Todo'
+import User from './components/User'
+import TodoApp from './containers/TodoApp'
+
+const reducer = combineReducers({
+  ...reducers,
+  routing: routerReducer
+})
+
+const DevTools = createDevTools(
+  <DockMonitor toggleVisibilityKey="ctrl-h" changePositionKey="ctrl-q">
+    <LogMonitor theme="tomorrow" preserveScrollTop={false} />
+  </DockMonitor>
+)
+
+const store = createStore(
+  reducer,
+  DevTools.instrument()
+)
+
+const history = syncHistoryWithStore(browserHistory, store)
+
+ReactDOM.render(
+  <Provider store={store}>
+    <TodoApp />
+  </Provider>, 
+  document.getElementById('main')
 );
 

--- a/src/js/components/Header.js
+++ b/src/js/components/Header.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import CSSModules from 'react-css-modules';
 import style from './Header.less';
+import { Link } from 'react-router';
 
 @CSSModules( style )
 export default class Header extends React.Component {
@@ -12,6 +13,7 @@ export default class Header extends React.Component {
     return (
       <div styleName="header">
         <p>React Todo Sample</p>
+				<Link to="/User">User test</Link>
       </div>
     );
   }

--- a/src/js/components/Header.js
+++ b/src/js/components/Header.js
@@ -12,8 +12,10 @@ export default class Header extends React.Component {
   render() {
     return (
       <div styleName="header">
-        <p>React Todo Sample</p>
-				<Link to="/User">User test</Link>
+        <ul>
+				  <li><Link to="/Todo">React Todo App</Link></li>
+				  <li><Link to="/User">User test</Link></li>
+        </ul>
       </div>
     );
   }

--- a/src/js/components/Header.less
+++ b/src/js/components/Header.less
@@ -8,5 +8,10 @@
     font-size: 48px;
     font-weight: 100;
   }
+
+  li {
+    display: inline-block;
+    width: 8%
+  }
 }
 

--- a/src/js/components/Todo.js
+++ b/src/js/components/Todo.js
@@ -1,9 +1,9 @@
 import React from 'react';
-import CSSModules from 'react-css-modules';
-import style from './Todo.less';
-import { Button } from 'react-bootstrap';
-import Header from './Header';
-import Contents from './TodoApp/Contents';
+import CSSModules from 'react-css-modules'
+import style from './Todo.less'
+import { Button } from 'react-bootstrap'
+import Header from './Header'
+import TodoApp from '../containers/TodoApp'
 
 @CSSModules( style )
 export default class Todo extends React.Component {
@@ -17,7 +17,7 @@ export default class Todo extends React.Component {
         <Header />
         <div styleName="todo">
           <div styleName="wrapper">
-            <Contents />
+            <TodoApp />
           </div>
         </div>
       </div>

--- a/src/js/components/Todo.js
+++ b/src/js/components/Todo.js
@@ -1,22 +1,24 @@
 import React from 'react';
 import CSSModules from 'react-css-modules';
-import style from './Main.less';
+import style from './Todo.less';
 import { Button } from 'react-bootstrap';
 import Header from './Header';
-import Contents from './Contents/Contents';
+import Contents from './TodoApp/Contents';
 
 @CSSModules( style )
-export default class Main extends React.Component {
+export default class Todo extends React.Component {
   constructor( props ) {
     super( props );
   }
 
   render() {
     return (
-      <div styleName="main">
-        <div styleName="wrapper">
-          <Header />
-          <Contents />
+      <div>
+        <Header />
+        <div styleName="todo">
+          <div styleName="wrapper">
+            <Contents />
+          </div>
         </div>
       </div>
     );

--- a/src/js/components/Todo.less
+++ b/src/js/components/Todo.less
@@ -3,13 +3,13 @@
  */
 :global html { height: 100%; }
 :global html body { height: 100%; }
-:global html body #main {
+:global html body #todo {
   height: 100%;
   font: 14px 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
 
 
-.main {
+.todo {
   height: 100%;
   background: whitesmoke;
   padding: 10px;

--- a/src/js/components/TodoApp/AddForm.js
+++ b/src/js/components/TodoApp/AddForm.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import CSSModules from 'react-css-modules';
+import style from './AddForm.less';
+import { FormControl } from 'react-bootstrap';
+
+@CSSModules( style )
+export default class AddForm extends React.Component {
+  constructor( props ) {
+    super( props );
+    this.state = { text: '' };
+  }
+
+  changeText( e ) {
+    this.setState({ text: e.target.value })
+  }
+
+  addTodo( e ) {
+    if ( e.keyCode !== 13/* enter key */ ) { return; }
+    e.preventDefault();
+    const text = this.state.text.trim();
+    if ( text ) {
+      this.props.addTodo( text );
+      this.setState({ text: '' });
+    }
+  }
+
+  render() {
+    return (
+      <div styleName="form">
+        <label styleName="title">Todo:</label>
+        <FormControl
+          type="text"
+          styleName="text"
+          placeholder="Enter text..."
+          onChange={ ::this.changeText }
+          onKeyDown={ ::this.addTodo }
+          value={ this.state.text }
+        />
+      </div>
+    );
+  }
+}
+

--- a/src/js/components/TodoApp/AddForm.js
+++ b/src/js/components/TodoApp/AddForm.js
@@ -1,13 +1,12 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
 import CSSModules from 'react-css-modules';
 import style from './AddForm.less';
 import { FormControl } from 'react-bootstrap';
 
 @CSSModules( style )
 export default class AddForm extends React.Component {
-  constructor( props ) {
-    super( props );
-    this.state = { text: '' };
+  state = {
+    text: this.props.text || ''
   }
 
   changeText( e ) {
@@ -39,5 +38,10 @@ export default class AddForm extends React.Component {
       </div>
     );
   }
+}
+
+AddForm.propTypes = {
+    addTodo: PropTypes.func.isRequired,
+    text: PropTypes.string
 }
 

--- a/src/js/components/TodoApp/AddForm.less
+++ b/src/js/components/TodoApp/AddForm.less
@@ -1,0 +1,17 @@
+.form {
+  flex-basis: 100px;
+  margin-bottom: 15px;
+  padding: 15px;
+
+  .title {
+    margin-left: -15px;
+    color: steelblue;
+  }
+
+  .text {
+    border: none;
+    background: transparent;
+    box-shadow: none;
+    border-bottom: 2px solid lightskyblue;
+  }
+}

--- a/src/js/components/TodoApp/Contents.js
+++ b/src/js/components/TodoApp/Contents.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import CSSModules from 'react-css-modules';
+import style from './Contents.less';
+import AddForm from './AddForm';
+import TodoList from './TodoList';
+
+@CSSModules( style )
+export default class Contents extends React.Component {
+  constructor( props ) {
+    super( props );
+    this.state = { todos: [] };
+  }
+
+  addTodo( text ) {
+    this.setState({
+      ...this.state,
+      todos: [
+        ...this.state.todos,
+        { text, completed: false, id: new Date().getTime() }
+      ]
+    });
+  }
+
+  toggle( id ) {
+    const todos = this.state.todos.map( todo => {
+      return todo.id == id ? { ...todo, completed: !todo.completed } : todo;
+    });
+    this.setState({ ...this.state, todos });
+  }
+
+  render() {
+    return (
+      <div styleName="contents">
+        <AddForm
+          addTodo={ ::this.addTodo }
+        />
+        <TodoList
+          todos={ this.state.todos }
+          toggle={ ::this.toggle }
+        />
+      </div>
+    );
+  }
+}
+

--- a/src/js/components/TodoApp/Contents.js
+++ b/src/js/components/TodoApp/Contents.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
 import CSSModules from 'react-css-modules';
 import style from './Contents.less';
 import AddForm from './AddForm';
@@ -6,11 +6,6 @@ import TodoList from './TodoList';
 
 @CSSModules( style )
 export default class Contents extends React.Component {
-  constructor( props ) {
-    super( props );
-    this.state = { todos: [] };
-  }
-
   addTodo( text ) {
     this.setState({
       ...this.state,
@@ -29,17 +24,23 @@ export default class Contents extends React.Component {
   }
 
   render() {
+    const { todos, actions } = this.props
     return (
       <div styleName="contents">
         <AddForm
-          addTodo={ ::this.addTodo }
+          addTodo={ actions.addTodo }
         />
         <TodoList
-          todos={ this.state.todos }
-          toggle={ ::this.toggle }
+          todos={ todos }
+          toggle={ actions.completeTodo }
         />
       </div>
     );
   }
+}
+
+Contents.propTypes = {
+    todos: PropTypes.array.isRequired,
+    actions: PropTypes.object.isRequired
 }
 

--- a/src/js/components/TodoApp/Contents.less
+++ b/src/js/components/TodoApp/Contents.less
@@ -1,0 +1,8 @@
+.contents {
+  padding: 15px;
+
+  flex: 1;
+
+  display: flex;
+  flex-direction: column;
+}

--- a/src/js/components/TodoApp/TodoList.js
+++ b/src/js/components/TodoApp/TodoList.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import CSSModules from 'react-css-modules';
+import style from './TodoList.less';
+import { Checkbox } from 'react-bootstrap';
+
+@CSSModules( style )
+export default class TodoList extends React.Component {
+  constructor( props ) {
+    super( props );
+  }
+
+  toggle( id, e ) {
+    this.props.toggle( id );
+  }
+
+  render() {
+    const todos = this.props.todos.map( todo => {
+      return (
+        <div key={ `todo${ todo.id }` } styleName="todo">
+          <Checkbox
+            styleName="check"
+            checked={ todo.completed }
+            onClick={ this.toggle.bind(this, todo.id) }
+          >
+          { todo.text }
+          </Checkbox>
+        </div>
+      );
+    });
+    return (
+      <div styleName="list">
+        { todos }
+      </div>
+    );
+  }
+}
+

--- a/src/js/components/TodoApp/TodoList.js
+++ b/src/js/components/TodoApp/TodoList.js
@@ -1,14 +1,10 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
 import CSSModules from 'react-css-modules';
 import style from './TodoList.less';
 import { Checkbox } from 'react-bootstrap';
 
 @CSSModules( style )
 export default class TodoList extends React.Component {
-  constructor( props ) {
-    super( props );
-  }
-
   toggle( id, e ) {
     this.props.toggle( id );
   }
@@ -33,5 +29,10 @@ export default class TodoList extends React.Component {
       </div>
     );
   }
+}
+
+TodoList.propTypes = {
+    todos: PropTypes.array.isRequired,
+    toggle: PropTypes.func.isRequired,
 }
 

--- a/src/js/components/TodoApp/TodoList.less
+++ b/src/js/components/TodoApp/TodoList.less
@@ -1,0 +1,15 @@
+.list {
+  flex: 1;
+
+  display: flex;
+  flex-direction: column;
+
+  .todo {
+    flex-basis: 20px;
+    padding-left: 15px;
+
+    .check {
+      font-size: 20px;
+    }
+  }
+}

--- a/src/js/components/User.js
+++ b/src/js/components/User.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import CSSModules from 'react-css-modules';
 import style from './User.less';
+import Header from './Header';
 
 @CSSModules( style )
 export default class User extends React.Component {
@@ -10,8 +11,11 @@ export default class User extends React.Component {
 
   render() {
     return (
-      <div styleName="user">
-        <p>React User</p>
+      <div>
+        <Header />
+        <div styleName="user">
+          <p>React User</p>
+        </div>
       </div>
     );
   }

--- a/src/js/components/User.js
+++ b/src/js/components/User.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import CSSModules from 'react-css-modules';
+import style from './User.less';
+
+@CSSModules( style )
+export default class User extends React.Component {
+  constructor( props ) {
+    super( props );
+  }
+
+  render() {
+    return (
+      <div styleName="user">
+        <p>React User</p>
+      </div>
+    );
+  }
+}
+

--- a/src/js/components/User.less
+++ b/src/js/components/User.less
@@ -1,0 +1,9 @@
+.user {
+
+  p {
+    margin-top: 10px;
+    text-align: center;
+    font-size: 48px;
+    font-weight: 100;
+  }
+}

--- a/src/js/constants/ActionTypes.js
+++ b/src/js/constants/ActionTypes.js
@@ -1,0 +1,2 @@
+export const ADD_TODO = 'ADD_TODO'
+export const COMPLETE_TODO = 'COMPLETE_TODO'

--- a/src/js/containers/TodoApp.js
+++ b/src/js/containers/TodoApp.js
@@ -1,0 +1,29 @@
+import React, { PropTypes } from 'react'
+import { bindActionCreators } from 'redux'
+import { connect } from 'react-redux'
+import Contents from '../components/TodoApp/Contents'
+import * as TodoActions from '../actions'
+
+const App = ({todos, actions}) => (
+  <div>
+    <Contents todos={todos} actions={actions} />
+  </div>
+)
+
+App.propTypes = {
+  todos: PropTypes.array.isRequired,
+  actions: PropTypes.object.isRequired
+}
+
+const mapStateToProps = state => ({
+  todos: state.todos
+})
+
+const mapDispatchToProps = dispatch => ({
+    actions: bindActionCreators(TodoActions, dispatch)
+})
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(App)

--- a/src/js/reducers/index.js
+++ b/src/js/reducers/index.js
@@ -1,0 +1,8 @@
+import { combineReducers } from 'redux'
+import todos from './todos'
+
+const rootReducer = combineReducers({
+  todos
+})
+
+export default rootReducer

--- a/src/js/reducers/index.js
+++ b/src/js/reducers/index.js
@@ -1,8 +1,1 @@
-import { combineReducers } from 'redux'
-import todos from './todos'
-
-const rootReducer = combineReducers({
-  todos
-})
-
-export default rootReducer
+export todos from './todos'

--- a/src/js/reducers/todos.js
+++ b/src/js/reducers/todos.js
@@ -1,0 +1,33 @@
+import { ADD_TODO, COMPLETE_TODO } from '../constants/ActionTypes'
+
+const initialState = [
+  {
+    text: 'Use Redux',
+    completed: false,
+    id: 0
+  }
+]
+
+export default function todos(state = initialState, action) {
+  switch (action.type) {
+    case ADD_TODO:
+      return [
+        {
+          text: action.text,
+          completed: false,
+          id: new Date().getTime(),
+        },
+        ...state
+      ]
+
+    case COMPLETE_TODO:
+      return state.map(todo =>
+        todo.id === action.id ?
+          { ...todo, completed: !todo.completed } :
+          todo
+      )
+
+    default:
+      return state
+  }
+}


### PR DESCRIPTION
#26 の対応です。

元のTodoアプリと、空の画面(User test)へ遷移できるリンクをヘッダに表示して、画面遷移できるようになっています。

こちらをのサンプルをだいぶ参考に(真似)しました。
https://github.com/reactjs/react-router-redux/tree/master/examples/basic

□注意点
masterブランチとの比較をしていますが、そのままでは、masterにはマージできません。
現状の進捗報告の意味でのpullリクエストとなります。
